### PR TITLE
Delete a bookmark

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -6,7 +6,9 @@ class BookmarksController < ApplicationController
 
   def destroy
     @bookmark = Bookmark.find(params[:id])
-    @bookmark.destroy
+    if @bookmark.destroy
+      flash[:notice] = "Successfully deleted wiki"
+    end
     redirect_to bookmarks_path
   end
 end

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,7 +1,12 @@
+<h1> My Bookmarks </h1>
 <% @tags.each do |tag| %>
-  <%= tag %>
-<% end %>
-<% @bookmarks.each do |bookmark|%>
-  <%= bookmark.url %>
-   
+  <%= content_tag :div, id: "#{tag}" do %>
+    <%= tag %>
+    <ul>
+    <#% @bookmarks.each do |bookmark|%>
+      <% @bookmarks.tagged_with(tag).each do |bookmark|%>
+        <li><%= bookmark.url %></li>
+      <% end %>
+    </ul>
+  <% end %>
 <% end %>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,12 +1,19 @@
 <h1> My Bookmarks </h1>
+
 <% @tags.each do |tag| %>
   <%= content_tag :div, id: "#{tag}" do %>
     <%= tag %>
-    <ul>
-    <#% @bookmarks.each do |bookmark|%>
+    <table class="table"> 
       <% @bookmarks.tagged_with(tag).each do |bookmark|%>
-        <li><%= bookmark.url %></li>
+        <tr>
+          <td>
+            <%= bookmark.url %>
+          </td>
+          <td>
+            <%= link_to "delete", bookmark, method: :delete %>
+          </td>
+        </tr>
       <% end %>
-    </ul>
+    </table>
   <% end %>
 <% end %>

--- a/spec/features/user_deletes_bookmarks_spec.rb
+++ b/spec/features/user_deletes_bookmarks_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+feature 'User deletes a bookmark he submitted' do
+  scenario 'successfully' do
+    url = "readhisword.com" 
+    user = create :user 
+    create :bookmark, user: user, url: url, tag_list: ["Spirit"]
+
+    login(user)
+    visit bookmarks_path
+    expect(page).to have_content(url)
+    click_link "delete"
+    expect(page).to have_content("Successfully deleted wiki")
+    expect(page).to_not have_content(url)
+  end
+
+  scenario "cannot delete someone else's bookmarks"
+end

--- a/spec/features/user_views_index_of_bookmarks_spec.rb
+++ b/spec/features/user_views_index_of_bookmarks_spec.rb
@@ -1,49 +1,37 @@
 require 'spec_helper'
 
-feature 'User visits bookmarks index and sees the bookmarks he has saved' do
+feature 'User visits bookmarks index' do 
 
   let(:user) {create(:user)}
   let(:user2) {create(:user)}
 
-
   scenario 'sees the bookmarks he owns' do
+    tag = "Powerhouse"
+    create(:bookmark, user: user, url: "google.com", tag_list: tag )
+    create(:bookmark, user: user, url: "apple.com", tag_list: tag ) 
 
-    #set up
-    user = create(:user)
-    create(:bookmark, user: user, url: "google.com")
-    create(:bookmark, user: user, url: "apple.com")
-
-    visit root_path
-    click_link 'Sign In'
-    fill_in 'Email', with: user.email
-    fill_in 'Password', with: user.password
-    click_button 'Sign in'
-
+    login(user)
     visit bookmarks_path
-
     expect(page).to have_content "google.com"
     expect(page).to have_content "apple.com"
   end
 
-
-
   scenario "does not see the ones he does not own" do
-
     create(:bookmark, user: user2, url: "user2.me")
-
     login(user) 
     visit bookmarks_path
-
     expect(page).to_not have_content "user2.me"
   end
 
   scenario "sees his bookmarks categorized by tag" do
-    @b = create(:bookmark, user: user, url: "user.me")
-    @b.tag_list.add("God's Economy")
-    @b.save
+    tag = "Economy"
+    url = "www.lettheword.com"
+    create(:bookmark, user: user, url: url, tag_list: tag )
+
     login(user)
     visit bookmarks_path
-
-    expect(page).to have_content ("God's Economy")
+    within("##{tag}") do
+      expect(page).to have_content (url)
+    end
   end
 end


### PR DESCRIPTION
@biblesforamerica/bloc 
added functionality for deleting a bookmark. 
still needs work: deleting a specific bookmark. 
Right now, the test just deletes the first bookmark on the page (by selecting the first 'delete' link)

implements issue #8 
